### PR TITLE
dev: Update to Scarb 2.6.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.5.3
-starknet-foundry 0.17.0
+scarb 2.6.3
+starknet-foundry 0.19.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -4,7 +4,7 @@ version = 1
 [[package]]
 name = "alexandria_bytes"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
  "alexandria_data_structures",
  "alexandria_math",
@@ -13,7 +13,7 @@ dependencies = [
 [[package]]
 name = "alexandria_data_structures"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
  "alexandria_encoding",
 ]
@@ -21,8 +21,9 @@ dependencies = [
 [[package]]
 name = "alexandria_encoding"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
+ "alexandria_bytes",
  "alexandria_math",
  "alexandria_numeric",
 ]
@@ -30,7 +31,7 @@ dependencies = [
 [[package]]
 name = "alexandria_math"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
  "alexandria_data_structures",
 ]
@@ -38,20 +39,20 @@ dependencies = [
 [[package]]
 name = "alexandria_numeric"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
  "alexandria_math",
 ]
 
 [[package]]
 name = "openzeppelin"
-version = "0.8.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=2815498#2815498b82e7cbc163cb9af9895bd573213d0f94"
+version = "0.10.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=f22438c#f22438cca0e81c807d7c1742e83050ebd0ffcb3b"
 
 [[package]]
 name = "snforge_std"
-version = "0.17.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.17.0#63f7f0b533a3d852e2b60214e0f40b99c9dcbb26"
+version = "0.19.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.19.0#a3391dce5bdda51c63237032e6cfc64fb7a346d4"
 
 [[package]]
 name = "succinct_sn"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -6,14 +6,16 @@ version = "0.1.0"
 test = "snforge test"
 
 [dependencies]
-alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "8ddf0243" }
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "2815498" }
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.17.0" }
-starknet = ">=2.5.3"
+alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "c1a604e" }
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "f22438c" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.19.0" }
+starknet = ">=2.6.3"
+
+[lib]
 
 [[target.starknet-contract]]
-casm = true
 sierra = true
+casm = true
 
 [tool.fmt]
 sort-module-level-items = true

--- a/src/mocks/erc20_mock.cairo
+++ b/src/mocks/erc20_mock.cairo
@@ -31,8 +31,8 @@ mod SnakeERC20Mock {
     #[constructor]
     fn constructor(
         ref self: ContractState,
-        name: felt252,
-        symbol: felt252,
+        name: ByteArray,
+        symbol: ByteArray,
         initial_supply: u256,
         recipient: ContractAddress
     ) {

--- a/src/tests/test_fee_vault.cairo
+++ b/src/tests/test_fee_vault.cairo
@@ -1,5 +1,4 @@
 use debug::PrintTrait;
-use openzeppelin::tests::utils::constants::{OWNER, NEW_OWNER, SPENDER};
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 use openzeppelin::utils::serde::SerializedAppend;
 use snforge_std::{
@@ -14,16 +13,30 @@ const INSUFFICIENT_VALUE: u256 = 0x1000;
 const DEDUCTION: u256 = 0x8000;
 const TOTAL_SUPPLY: u256 = 0x100000000000000000000000000000001;
 
+fn OWNER() -> ContractAddress {
+    contract_address_const::<'OWNER'>()
+}
+
+fn NEW_OWNER() -> ContractAddress {
+    contract_address_const::<'NEW_OWNER'>()
+}
+
+fn SPENDER() -> ContractAddress {
+    contract_address_const::<'SPENDER'>()
+}
+
 fn setup_contracts() -> (IERC20Dispatcher, IFeeVaultDispatcher) {
     let mut calldata = array![];
-    calldata.append_serde('FeeToken');
-    calldata.append_serde('FT');
+    let token_name: ByteArray = "FeeToken";
+    let token_symbol: ByteArray = "FT";
+    calldata.append_serde(token_name);
+    calldata.append_serde(token_symbol);
     calldata.append_serde(TOTAL_SUPPLY);
     calldata.append_serde(OWNER());
-    let token_class = declare('SnakeERC20Mock');
+    let token_class = declare("SnakeERC20Mock");
     let token_address = token_class.deploy(@calldata).unwrap();
 
-    let fee_vault_class = declare('succinct_fee_vault');
+    let fee_vault_class = declare("succinct_fee_vault");
     let fee_calldata = array![token_address.into(), OWNER().into()];
     let fee_vault_address = fee_vault_class.deploy(@fee_calldata).unwrap();
     (


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/blobstream-starknet/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests
- [x] breaking change

<!-- PR description below -->
Update dependencies and self to `scarb` 2.6.3 and `snforge` 0.19.0.

This is needed to allow us to use the latest versions of `openzeppelin` and `Alexandria` in this project and Blobstream SN.