### PR TITLE
feat: Generic verified output

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -4,7 +4,7 @@ version = 1
 [[package]]
 name = "alexandria_bytes"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=39ccd99#39ccd99b1c017ba1c6b53f6d74775f5ab0054735"
 dependencies = [
  "alexandria_data_structures",
  "alexandria_math",
@@ -13,7 +13,7 @@ dependencies = [
 [[package]]
 name = "alexandria_data_structures"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=39ccd99#39ccd99b1c017ba1c6b53f6d74775f5ab0054735"
 dependencies = [
  "alexandria_encoding",
 ]
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "alexandria_encoding"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=39ccd99#39ccd99b1c017ba1c6b53f6d74775f5ab0054735"
 dependencies = [
  "alexandria_bytes",
  "alexandria_math",
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "alexandria_math"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=39ccd99#39ccd99b1c017ba1c6b53f6d74775f5ab0054735"
 dependencies = [
  "alexandria_data_structures",
 ]
@@ -39,9 +39,18 @@ dependencies = [
 [[package]]
 name = "alexandria_numeric"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=39ccd99#39ccd99b1c017ba1c6b53f6d74775f5ab0054735"
 dependencies = [
  "alexandria_math",
+ "alexandria_searching",
+]
+
+[[package]]
+name = "alexandria_searching"
+version = "0.1.0"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=39ccd99#39ccd99b1c017ba1c6b53f6d74775f5ab0054735"
+dependencies = [
+ "alexandria_data_structures",
 ]
 
 [[package]]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 test = "snforge test"
 
 [dependencies]
-alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "c1a604e" }
+alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "39ccd99" }
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "f22438c" }
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.19.0" }
 starknet = ">=2.6.3"

--- a/src/interfaces.cairo
+++ b/src/interfaces.cairo
@@ -29,7 +29,7 @@ trait ISuccinctGateway<TContractState> {
         entry_calldata: Bytes,
         entry_gas_limit: u32
     );
-    fn verified_call(self: @TContractState, function_id: u256, input: Bytes) -> (u256, u256);
+    fn verified_call(self: @TContractState, function_id: u256, input: Bytes) -> Bytes;
     fn fulfill_callback(
         ref self: TContractState,
         nonce: u32,


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/blobstream-starknet/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests
- [x] breaking change

<!-- PR description below -->
I changed `verified_output` to a generic `Bytes` type and updated the Alexandria dependency to use the new Byte's Store trait.
